### PR TITLE
Refactor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Titus Wormer <tituswormer@gmail.com>
 Christopher Jeffrey <chjjeffrey@gmail.com>
+YJ Yang <chcokr@gmail.com>
 Hsiaoming Yang <lepture@me.com>
 Chris Wren <cthewren@gmail.com>
 anonymous (Mithgol) <getgit@mithgol.ru>
@@ -7,11 +8,13 @@ Kitson Kelly <dojo@kitsonkelly.com>
 Hsiaoming Yang <me@lepture.com>
 MinRK <benjaminrk@gmail.com>
 Isaac Z. Schlueter <i@izs.me>
+Ben Briggs <beneb.info@gmail.com>
 Ian Storm Taylor <ian@ianstormtaylor.com>
 Brad Harris <bmharris@gmail.com>
 Maksim Kozhukh <mkozhukh@ya.ru>
 Martin Zagora <zaggino@gmail.com>
 Matias Niemelä <matias@yearofmoo.com>
+Eugene Sharygin <eush77@gmail.com>
 Matt Brennan <mattyb1000@gmail.com>
 Maxime Thirouin <m@moox.io>
 Mikeal Rogers <mikeal.rogers@gmail.com>
@@ -33,4 +36,3 @@ Jason Karns <jason@karns.name>
 John Long <jlong@carouselchecks.com>
 Julian Taylor <jtaylor.debian@googlemail.com>
 Komatsu Seiji <skomatsu.comutt@gmail.com>
-YJ Yang <chcokr@gmail.com>

--- a/doc/mdast.1.md
+++ b/doc/mdast.1.md
@@ -97,7 +97,7 @@ COMMAND LINE USAGE for more information.
 ### `-e`, `--ext` <_extensions_>
 
 ```sh
-mdast --ext .doc
+mdast --ext doc
 ```
 
 Specify one or more extensions to include when searching for files.
@@ -105,6 +105,27 @@ This will add the given `extensions` to the internal list, which includes
 `'md'`, `'markdown'`, `'mkd'`, `'mkdn'`, `'mkdown'`, and `'ron'`.
 
 The given `extensions` can be comma or semi-colon separated.
+
+### `-w`, `--watch`
+
+```sh
+mdast -w .
+```
+
+Watch all files and reprocess when they change.
+
+When watching files which would normally regenerate,
+this behavior is ignored until the watch is closed.
+
+```sh
+$ mdast --no-rc readme.md -oqw
+# Watching... (press CTRL+C to exit)
+# Warning: mdast does not overwrite watched files until exit.
+# Messages and other files are not affected.
+```
+
+The watch is stopped when `SIGINT` is received (usually done by pressing
+`CTRL-C`).
 
 ### `-a`, `--ast`
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -19,6 +19,8 @@ var events = require('events');
 var commander = require('commander');
 var camelcase = require('camelcase');
 var pack = require('../../package.json');
+var Cache = require('./watch-output-cache');
+var Spinner = require('./spinner');
 
 /*
  * Methods.
@@ -228,8 +230,7 @@ var program = new Command(pack.name)
     .option('-s, --setting <settings>', 'specify settings', options, {})
     .option('-u, --use <plugins>', 'use transform plugin(s)', plugins, {})
     .option('-e, --ext <extensions>', 'specify extensions', extensions, [])
-    .option('-w, --watch',
-        'watch for changes and reprocess (ignores output)', false)
+    .option('-w, --watch', 'watch for changes and reprocess', false)
     .option('-a, --ast', 'output AST information', false)
     .option('-q, --quiet', 'output only warnings and errors', false)
     .option('-S, --silent', 'output only errors', false)
@@ -259,6 +260,9 @@ program.on('--help', help);
 function CLI(argv) {
     var self = this;
     var config = argv;
+
+    self.cache = new Cache();
+    self.spinner = new Spinner();
 
     if ('length' in config) {
         program.parse(argv);

--- a/lib/cli/file-pipeline/file-system.js
+++ b/lib/cli/file-pipeline/file-system.js
@@ -14,7 +14,6 @@
 
 var fs = require('fs');
 var debug = require('debug')('mdast:cli:file-pipeline:file-system');
-var watchOutputCache = require('../watch-output-cache');
 
 /*
  * Methods.
@@ -46,6 +45,9 @@ var writeFile = fs.writeFile;
  */
 function fileSystem(context, done) {
     var file = context.file;
+    var fileSet = context.fileSet;
+    var cli = fileSet.cli;
+    var sourcePaths = fileSet.sourcePaths;
     var destinationPath;
 
     if (!context.output) {
@@ -74,35 +76,24 @@ function fileSystem(context, done) {
         return;
     }
 
-    var cli = context.fileSet.cli;
+    /*
+     * When watching, `sourcePath`s are watched.  Thus, we
+     * check if we are planning on writing to a watched
+     * file-path. In which case we exit.
+     */
 
-    var watch = cli.watch && // cli.watch checks whether --watch flag is used
-        /*
-         * It is important that we compare destinationPath against
-         * fileSet.sourcePaths - it is essential to understand what each of
-         * these two means in this context.
-         *
-         * fileSet.sourcePaths, as discussed in ../index.js, represents the
-         * files we are watching.
-         *
-         * destinationPath represents the path to which something is about to
-         * get written to.
-         *
-         * So what the following check means is "the file that is about to be
-         * written to is also being watched."
-         */
-        (context.fileSet.sourcePaths.indexOf(destinationPath) !== -1);
+    if (cli.watch && (sourcePaths.indexOf(destinationPath) !== -1)) {
+        debug('Caching document as `%s` is watched', destinationPath);
 
-    if (!watch) {
+        cli.cache.add(file);
+
+        done();
+    } else {
         debug('Writing document to `%s`', destinationPath);
 
         file.stored = true;
 
         writeFile(destinationPath, file.toString(), done);
-    } else {
-        watchOutputCache.add(file);
-
-        done();
     }
 }
 

--- a/lib/cli/file-set-pipeline/log.js
+++ b/lib/cli/file-set-pipeline/log.js
@@ -12,10 +12,19 @@
  * Dependencies.
  */
 
-var charm = require('charm')(process.stdout);
 var chalk = require('chalk');
-var logUpdate = require('log-update');
 var report = require('vfile-reporter');
+
+/**
+ * Check whether `file` is provided by the user.
+ *
+ * @param {File} file - Virtual file.
+ * @return {boolean?} - whether `file` is provided by the
+ *   user.
+ */
+function isProvidedByUser(file) {
+    return file.namespace('mdast:cli').providedByUser;
+}
 
 /**
  * Output diagnostics to stdout(4) or stderr(4).
@@ -24,40 +33,22 @@ var report = require('vfile-reporter');
  */
 function log(context) {
     var files = context.files;
-    var applicables = files.filter(function (file) {
-        return file.namespace('mdast:cli').providedByUser;
+    var applicables = files.filter(isProvidedByUser);
+    var diagnostics = report(applicables, {
+        'quiet': context.quiet,
+        'silent': context.silent
     });
 
-    if (!context.watch) {
-        outputReports();
-    } else {
-        // Clear out the spinner. See also ../index.js
-        logUpdate('');
-        /*
-         * Without the following line, an additional newline will be added to
-         * the output every time this function is invoked.
-         */
-        charm.up(1);
-
-        outputReports();
-    }
-
-    /**
+    /*
      * Outputs the reports.
      */
-    function outputReports() {
-        var diagnostics = report(applicables, {
-            'quiet': context.quiet,
-            'silent': context.silent
-        });
 
-        if (!context.color) {
-            diagnostics = chalk.stripColor(diagnostics);
-        }
+    if (!context.color) {
+        diagnostics = chalk.stripColor(diagnostics);
+    }
 
-        if (diagnostics) {
-            context.stderr(diagnostics);
-        }
+    if (diagnostics) {
+        context.stderr(diagnostics);
     }
 }
 

--- a/lib/cli/file-set.js
+++ b/lib/cli/file-set.js
@@ -68,8 +68,20 @@ function one(fileSet) {
 function FileSet(cli) {
     var self = this;
 
+    /**
+     * Access files in the file-set.
+     *
+     * @member {Array.<VFile>}
+     */
     self.contents = [];
+
+    /**
+     * Track the file-paths of files when they were added.
+     *
+     * @member {Array.<string>}
+     */
     self.sourcePaths = [];
+
     self.cli = cli;
     self.length = 0;
     self.count = 0;

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -16,9 +16,36 @@ var chalk = require('chalk');
 var chokidar = require('chokidar');
 var CLI = require('./cli');
 var fileSetPipeline = require('./file-set-pipeline');
-var logUpdate = require('log-update');
-var spinner = require('elegant-spinner');
-var watchOutputCache = require('./watch-output-cache');
+
+/**
+ * Run the file set pipeline once.
+ *
+ * @param {CLI} cli - A CLI instance.
+ * @param {function(Error?, boolean)} done - Callback
+ *   invoked when done.
+ */
+function run(cli, done) {
+    cli.spinner.stop();
+
+    fileSetPipeline.run(cli, function (err) {
+        /*
+         * Check if any file has failed.
+         */
+
+        var hasFailed = (cli.files || []).some(function (file) {
+            return (file.messages || []).some(function (message) {
+                return message.fatal === true ||
+                    (message.fatal === false && cli.frail);
+            });
+        });
+
+        done(err, !hasFailed);
+
+        if (!err && cli.watch) {
+            cli.spinner.start();
+        }
+    });
+}
 
 /**
  * CLI engine. This is used by `bin/mdast`.
@@ -32,132 +59,62 @@ var watchOutputCache = require('./watch-output-cache');
  */
 function engine(argv, done) {
     var cli = new CLI(argv);
+    var enabled = chalk.enabled;
+    var watcher;
 
     chalk.enabled = cli.color;
 
-    if (!cli.watch) {
-        run(cli, true, done);
-    } else {
-        cli.stderr([
-            'If a file you\'re watching will be written to as a result of',
-            'running the plugins, mdast will not rewrite over the file, but',
-            'instead hold the output in memory - to avoid race conditions.',
-            'When you exit the watch with a SIGINT (CTRL+C), then mdast will',
-            'rewrite over the file with the latest output in memory.'
-        ].join('\n'));
+    if (cli.watch) {
+        cli.stdout(chalk.bold('Watching...') + ' (press CTRL+C to exit)')
+    }
 
-        var watcher;
+    run(cli, function (err, success) {
+        chalk.enabled = enabled;
 
-        run(cli, true, function (err, success) {
-            /*
-             * We pass cli.fileSet.sourcePaths into chokidar.watch().
-             * Note that this variable holds paths to not only the files that
-             * the user wants to watch (as specified in argv), but also the
-             * files that would be affected as a result of running the plugins
-             * or have an impact on the validity of a file that the user wants
-             * to watch.
-             *
-             * This may not sound intuitive initially as the user didn't ask
-             * us to watch the extra dependent files.
-             * However, there really are use cases for doing this.
-             * For example, the plugin mdast-validate-links checks if the
-             * links referred to in a file (call it main.md) are valid.
-             * If one of the files which a link refers to changes, then it's
-             * a good idea to re-validate main.md.
-             *
-             * Let's now talk about a different scenario.
-             * Say main.md causes a rewrite over a file called dependent.md,
-             * but changing dependent.md doesn't have any impact on main.md.
-             * In this case, there is zero harm to watch dependent.md.
-             * If the user for some reason changes dependent.md in the middle
-             * of the watch, nothing will happen but the fact that
-             * dependent.md has changed - so there is no confusion on the
-             * user's part!
-             */
-            watcher = chokidar.watch(cli.fileSet.sourcePaths, {
-                ignoreInitial: true
-            }).on('all', function (type) {
-                if (type === 'add' || type === 'change') {
-                    run(cli, false, done);
-                }
-            }).on('error', done);
+        done(err, success);
 
-            done(err, success);
-        });
+        /*
+         * Exit when not-watching, or when an error
+         * has occurred.
+         */
+
+        if (err || !cli.watch) {
+            return;
+        }
+
+        /*
+         * Trigger warning when files need to be cached.
+         */
+
+        if (cli.cache.length) {
+            cli.stderr(
+                chalk.yellow('Warning') + ': mdast does not overwrite ' +
+                'watched files until exit.\nMessages and other files are ' +
+                'not affected.'
+            );
+        }
+
+        /*
+         * Watch files source-locations of files in
+         * the file-set.
+         */
+
+        watcher = chokidar.watch(cli.fileSet.sourcePaths, {
+            'ignoreInitial': true
+        }).on('all', function (type) {
+            if (type === 'add' || type === 'change') {
+                run(cli, done);
+            }
+        }).on('error', done);
 
         process.on('SIGINT', function () {
-            watchOutputCache.writeAll();
+            cli.cache.writeAll();
 
             if (watcher) {
                 watcher.close();
             }
         });
-    }
-}
-
-/**
- * Run the file set pipeline once.
- *
- * @param {CLI} cli - A CLI instanc.
- * @param {bool} isFirstRunOfWatchSession - Whether
- * this run is the first time it is being called in
- * the current watch session.
- * @param {function(Error?, boolean)} done - Callback
- *   invoked when done.
- */
-function run(cli, isFirstRunOfWatchSession, done) {
-    var enabled = chalk.enabled;
-
-    var getSpinnerFrame;
-    if (cli.watch) {
-        // Spin the spinner!
-        getSpinnerFrame = spinner();
-        var spinnerIntervalId = setInterval(function () {
-            logUpdate(getSpinnerFrame());
-        }, 50);
-    }
-
-    fileSetPipeline.run(cli, function (err) {
-        /*
-         * The following clearInterval() stops the spinner from further
-         * animation, but it does not clear out the spinner off of the
-         * console.
-         * That part is taken care of in ./file-set-pipeline/log.js .
-         * We don't clear out the spinner here for the following reason.
-         * The way a spinner is cleared out is by erasing the last line in
-         * the console.
-         * If we do that here, the last line of all the plugins' output will
-         * be erased, instead of the spinner.
-         */
-        clearInterval(spinnerIntervalId);
-
-        /*
-         * Check if any file has failed.
-         */
-
-        var hasFailed = (cli.files || []).some(function (file) {
-            return (file.messages || []).some(function (message) {
-                return message.fatal === true ||
-                    (message.fatal === false && cli.frail);
-            });
-        });
-
-        chalk.enabled = enabled;
-
-        done(err, !hasFailed);
     });
-
-    if (!isFirstRunOfWatchSession) {
-        /*
-         * Without the following, the last line of the output from a non-first
-         * pipeline run could get deleted, when ./file-set-pipeline/log.js
-         * tries to clear out the spinner.
-         *
-         * In contrast, if the following is called also on the *first*
-         * pipeline run, then you will see an extra spinner.
-         */
-        cli.stdout(getSpinnerFrame());
-    }
 }
 
 /*

--- a/lib/cli/spinner.js
+++ b/lib/cli/spinner.js
@@ -1,0 +1,89 @@
+/**
+ * @author Titus Wormer
+ * @copyright 2015 Titus Wormer
+ * @license MIT
+ * @module mdast:cli:spinner
+ * @fileoverview A spinner for stdout(4).
+ */
+
+'use strict';
+
+/*
+ * Dependencies.
+ */
+
+var charm = require('charm')(process.stdout);
+var logUpdate = require('log-update');
+var spinner = require('elegant-spinner');
+
+/**
+ * Spinner.
+ *
+ * @example
+ *   var spinner = new Spinner();
+ *
+ * @constructor
+ * @class {FileSet}
+ */
+function Spinner() {}
+
+/**
+ * Start spinning.
+ *
+ * @example
+ *   new Spinner().start();
+ *
+ * @this {Spinner}
+ * @return {Spinner} - Self.
+ */
+function start() {
+    var self = this;
+    var spin = spinner();
+
+    if (!self.id) {
+        self.id = setInterval(function () {
+            logUpdate(spin());
+        }, 100);
+    }
+
+    return self;
+}
+
+/**
+ * Stop spinning.
+ *
+ * @example
+ *   spinner = new Spinner().start();
+ *   setTimeout(function () { spinner.stop(); }, 1000);
+ *
+ * @this {Spinner}
+ * @return {Spinner} - Self.
+ */
+function stop() {
+    var self = this;
+
+    if (self.id) {
+        logUpdate('');
+        logUpdate.clear();
+        charm.up(1);
+        clearInterval(self.id);
+        self.id = null;
+    }
+
+    return self;
+}
+
+/*
+ * Attach.
+ */
+
+var proto = Spinner.prototype;
+
+proto.start = start;
+proto.stop = stop;
+
+/*
+ * Expose.
+ */
+
+module.exports = Spinner;

--- a/lib/cli/watch-output-cache.js
+++ b/lib/cli/watch-output-cache.js
@@ -1,46 +1,73 @@
 /**
  * @author YJ Yang
- * @copyright 2015 YJ Yang
+ * @copyright 2015 Titus Wormer
  * @license MIT
- * @module mdast:cli:watch:output-cache
- * @fileoverview Maintain a cache of outputs to files that are being watched
- *  and were also going to be written to.
+ * @module mdast:cli:watch-output-cache
+ * @fileoverview Cache changed files which are also watched.
  */
 
 'use strict';
 
-var debug = require('debug')('mdast:cli:watch:output-cache');
+/*
+ * Dependencies.
+ */
+
+var debug = require('debug')('mdast:cli:watch-output-cache');
 var fs = require('fs');
 
 /**
- * This object keeps a mapping from a VFile's #filePath() to itself.
- * The point of using the paths as keys in this object is so that, in
- * #writeAll(), we write to each file in the cache just once.
- * @type {{}}
+ * Construct a new cache.
+ *
+ * @example
+ *   var cache = new Cache();
+ *
+ * @constructor
+ * @class {Cache}
  */
-var cache = {};
+function Cache() {
+    /**
+     * Map of file-path’s to files, containing changed files
+     * which are also watched.
+     *
+     * @member {Object}
+     */
+    this.cache = {};
+
+    /**
+     * Number of cached files.
+     *
+     * @member {number}
+     */
+    this.length = 0;
+}
 
 /**
  * Add a VFile to the cache so that its content can later be used.
  *
+ * @this {Cache}
  * @param {VFile} file - The file to add to the cache.
  */
 function add(file) {
-    var filePath = file.filePath();
+    var filePath = file.sourcePath || file.filePath();
 
-    cache[filePath] = file;
+    this.cache[filePath] = file;
+    this.length++;
 
-    debug('File has been added to watchOutputCache: %s', filePath);
+    debug('Add document at %s to cache', filePath);
 }
 
 /**
  * Write to all the files in the cache.
  * This function is synchronous.
+ *
+ * @this {Cache}
  */
 function writeAll() {
+    var self = this;
+    var cache = self.cache;
+
     Object.keys(cache).forEach(function (path) {
         var file = cache[path];
-
         var destinationPath = file.filePath();
 
         debug('Writing document to `%s`', destinationPath);
@@ -48,20 +75,30 @@ function writeAll() {
         file.stored = true;
 
         /*
-         * It might be tempting to use the async version fs.writeFile here,
-         * but that comes with a lot of additional complexity, especially in
-         * terms of coordinating order between chokidar and file writes.
-         * For example, if you switch this to the async version, you will
-         * notice that the target files end up turning blank, because closing
-         * out chokidar's watcher will terminate the process too early before
-         * the files are written to.
-         * Leaving this in the synchronous version here is strongly suggested.
+         * Chokidar’s watcher stops the process abruptly,
+         * so we need to use synchronous writes here.
         */
+
         fs.writeFileSync(destinationPath, file.toString());
     });
 
-    debug('All the outputs held in memory have been written to the files!');
+    self.length = 0;
+    self.cache = {};
+
+    debug('Written all cached documents');
 }
 
-module.exports.add = add;
-module.exports.writeAll = writeAll;
+/*
+ * Attach.
+ */
+
+var proto = Cache.prototype;
+
+proto.add = add;
+proto.writeAll = writeAll;
+
+/*
+ * Expose.
+ */
+
+module.exports = Cache;

--- a/man/mdast.1
+++ b/man/mdast.1
@@ -94,13 +94,35 @@ Specify a plug-in to use, optionally with options. See \fBmdastplugin\fR(7) COMM
 .P
 .RS 2
 .nf
-mdast --ext .doc
+mdast --ext doc
 .fi
 .RE
 .P
 Specify one or more extensions to include when searching for files. This will add the given \fBextensions\fR to the internal list, which includes \fB\[aq]md\[aq]\fR, \fB\[aq]markdown\[aq]\fR, \fB\[aq]mkd\[aq]\fR, \fB\[aq]mkdn\[aq]\fR, \fB\[aq]mkdown\[aq]\fR, and \fB\[aq]ron\[aq]\fR.
 .P
 The given \fBextensions\fR can be comma or semi-colon separated.
+.SS "\fB-w\fR, \fB--watch\fR"
+.P
+.RS 2
+.nf
+mdast -w .
+.fi
+.RE
+.P
+Watch all files and reprocess when they change.
+.P
+When watching files which would normally regenerate, this behavior is ignored until the watch is closed.
+.P
+.RS 2
+.nf
+\[Do] mdast --no-rc readme.md -oqw
+\[sh] Watching... (press CTRL\[pl]C to exit)
+\[sh] Warning: mdast does not overwrite watched files until exit.
+\[sh] Messages and other files are not affected.
+.fi
+.RE
+.P
+The watch is stopped when \fBSIGINT\fR is received (usually done by pressing \fBCTRL-C\fR).
 .SS "\fB-a\fR, \fB--ast\fR"
 .P
 .RS 2


### PR DESCRIPTION
-   Refactor list of authors to additionally include
  other mdast authors,  and re-order.
  
  More info:
  
  ```
  https://github.com/tj/git-extras/blob/
  c8aca55cd70b52079fd76703ba3b54aaef8fe9fe/bin/git-authors
  ```
-   Change copyright of `watch-output-cache` to me. Although I really
  appreciate your work, and do recognize it (e.g., in AUTHORS) and
  in the repo, if you assign these rights over it makes future changes
  without consulting you easier. Although I phrase this as a question,
  I do not think having code copyrighted to others is viable. Thus,
  for me to merge this, this change is of vital importance.
  
  More info:
  
  ```
  http://haacked.com/archive/2006/01/26/
  WhoOwnstheCopyrightforAnOpenSourceProject.aspx/
  ```
-   I refactor the cache to be a class, this allows multiple watching
  mdast instances in a single process.
-   I refactored the spinner to spin when waiting between `run`s,
  I found that, when actually running, the thread was so full that
  the spinner got stuck. Now, when watching, you see the spinner
  spinning which I really like (try it out, this is IMO for the
  better!)
  
  In addition, the spinner is extracted into a new file, which
  contains all code needed for it to work.
-   I moved functions which were hoisted above the place they
  were used.
-   I moved variable declarations to the start of their scope.
-   I refactored some comments to be less verbose. I appreciate
  your extensiveness in these comments, it helps me understand why
  things happen this way, but they were very verbose.
  
  Some were moved to the place where entities were created,
  e.g., `sourcePaths`, and others were rewritten.
-   I refactor the warning message when files are cached instead of
  written. This change ensures it’s only shown when needed.
  
  I additionally split it into two: a message about quitting
  the watch using `CTRL+C` (which is always shown), and the warning
  when applicable.
-   Docs.
