### PR TITLE
Refactor to fix and simplify

### DIFF
--- a/lib/cli/file-set-pipeline/configure.js
+++ b/lib/cli/file-set-pipeline/configure.js
@@ -28,20 +28,16 @@ var Configuration = require('../configuration');
  * @param {CLI} cli
  */
 function configure(cli) {
-    if (cli.changedFilePath) {
-        return;
+    if (!cli.configuration) {
+        cli.configuration = new Configuration({
+            'detectRC': cli.detectRC,
+            'file': cli.configPath,
+            'settings': cli.settings,
+            'plugins': cli.plugins,
+            'output': cli.output,
+            'cwd': cli.cwd
+        });
     }
-
-    var configuration = new Configuration({
-        'detectRC': cli.detectRC,
-        'file': cli.configPath,
-        'settings': cli.settings,
-        'plugins': cli.plugins,
-        'output': cli.output,
-        'cwd': cli.cwd
-    });
-
-    cli.configuration = configuration;
 }
 
 /*

--- a/lib/cli/file-set-pipeline/stdin.js
+++ b/lib/cli/file-set-pipeline/stdin.js
@@ -38,12 +38,6 @@ var expextPipeIn = !isTTY;
 function stdin(program, callback) {
     var err;
 
-    if (program.changedFilePath) {
-        callback();
-
-        return;
-    }
-
     debug('Checking stdin');
 
     if (program.files.length) {

--- a/lib/cli/file-set-pipeline/transform.js
+++ b/lib/cli/file-set-pipeline/transform.js
@@ -31,15 +31,7 @@ function transform(cli, done) {
 
     fileSet.done = done;
 
-    if (!cli.changedFilePath) {
-        cli.files.forEach(fileSet.add, fileSet);
-    } else {
-        cli.files.forEach(function (file) {
-            if (file.filePath()=== cli.changedFilePath) {
-                fileSet.add(file);
-            }
-        });
-    }
+    cli.files.forEach(fileSet.add, fileSet);
 
     cli.fileSet = fileSet;
 }

--- a/lib/cli/file-set-pipeline/traverse.js
+++ b/lib/cli/file-set-pipeline/traverse.js
@@ -27,10 +27,6 @@ var Traverser = require('../traverser');
  * @param {CLI} cli
  */
 function traverse(cli) {
-    if (cli.changedFilePath) {
-        return;
-    }
-
     var traverser = new Traverser({
         'extensions': cli.extensions,
         'ignorePath': cli.ignorePath,

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -103,9 +103,10 @@ function engine(argv, done) {
 
         watcher = chokidar.watch(cli.fileSet.sourcePaths, {
             'ignoreInitial': true
-        }).on('all', function (type, path) {
+        }).on('all', function (type, filePath) {
             if (type === 'add' || type === 'change') {
-                cli.changedFilePath = path;
+                cli.globs = [filePath];
+
                 run(cli, done);
             }
         }).on('error', done);


### PR DESCRIPTION
Your changes were on the right track but there was no need to create a new property (`changedFilePath`), or check for that if a single file was provided.

In fact, there’s already an object which is patched on every run (the CLI). As in, on the first run it’s empty, but future runs are completely patched, so we can check for that (see `lib/cli/file-set-pipeline/configure.js:31`). 

Additionally, instead of creating a new system for these one-file processes, `changedFilePath`, I opted to re-use the existing `cli.globs`, which is used by `traverser`.

Traverser can do some funky stuff when needed and when directories are given, but in this case it doesn’t really do too much. Performance is a lot higher when processing just one file (and of course, other files added by plug-ins like mdast-validate-links) versus a huge batch of documentation.

Currently, changing mdastrc(5) files is ignored (the config has a cache by file-path at `cli.config.cache`). Changing mdastignore(5) files however do take affect, as they are reloaded on each run. I’m not sure whether any choice is good here: having no caching can be expensive, having to exit a watch for changes to take affect isn’t very user-friendly either.
